### PR TITLE
feat: use git to "ensure lint is not configured to --fix"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,7 +48,16 @@ jobs:
           fi
 
       - run: npm run build --if-present
-      - run: npm run lint --if-present -- --fix=false # ensure eslint is not configured to --fix
+      - run: npm run lint --if-present
+      - run: |
+          changes=$(git status --porcelain)
+          if [ -n "$changes" ]; then
+            echo "Found uncommitted changes after running lint."
+            echo "(ensure lint is not configured to --fix)"
+            echo "$changes"
+            exit 1
+          fi
+        shell: "bash"
       - run: npm run test --if-present
 
 

--- a/action.yml
+++ b/action.yml
@@ -41,7 +41,16 @@ runs:
 
     - run: npm run build --if-present
       shell: "bash"
-    - run: npm run lint --if-present -- --fix=false # ensure eslint is not configured to --fix
+    - run: npm run lint --if-present
+      shell: "bash"
+    - run: |
+        changes=$(git status --porcelain)
+        if [ -n "$changes" ]; then
+          echo "Found uncommitted changes after running lint."
+          echo "(ensure lint is not configured to --fix)"
+          echo "$changes"
+          exit 1
+        fi
       shell: "bash"
     - run: npm run test --if-present
       shell: "bash"


### PR DESCRIPTION
Preparing for migration to oxlint/oxfmt from eslint/prettier.

Only eslint supports "--fix=false".

- use "git status --porcelain" to check for uncommitted changes